### PR TITLE
Cabal version bump

### DIFF
--- a/session-prefixes.cabal
+++ b/session-prefixes.cabal
@@ -14,7 +14,7 @@ extra-doc-files:    CHANGELOG.md
 
 
 common defaults
-  build-depends: base ^>=4.16 || ^>=4.17 || ^>=4.18 || ^>=4.19 || ^>=4.20
+  build-depends: base ^>=4.16 || ^>=4.17 || ^>=4.18 || ^>=4.19 || ^>=4.20 || ^>=4.21
   default-language: GHC2021
   default-extensions:
     BlockArguments
@@ -34,7 +34,7 @@ common defaults
 common deps
   build-depends:
     containers ^>=0.6,
-    hashable ^>= 1.4.3,
+    hashable ^>= 1.5,
     megaparsec ^>=9.6.1,
     prettyprinter ^>=1.7,
     semialign ^>=1.3,
@@ -60,7 +60,7 @@ executable session-prefixes
 
   build-depends:
     session-prefixes,
-    brick ^>=2.3.1,
+    brick ^>=2.8,
     microlens-platform ^>=0.4.3,
     vty ^>=6.2,
 


### PR DESCRIPTION
Had to adjust some version bounds to work with ghc 9.12.1